### PR TITLE
Update StyleCop to latest version

### DIFF
--- a/Cake.Stylecop/Cake.StyleCop.csproj
+++ b/Cake.Stylecop/Cake.StyleCop.csproj
@@ -40,17 +40,17 @@
       <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StyleCop, Version=4.7.1000.0, Culture=neutral, PublicKeyToken=f904653c63bc2738, processorArchitecture=MSIL">
-      <HintPath>..\packages\StyleCop.Rules.4.7.49\lib\net40\StyleCop.dll</HintPath>
       <Private>True</Private>
+    <Reference Include="StyleCop">
+      <HintPath>..\packages\StyleCop.MSBuild.4.7.55.0\tools\StyleCop.dll</HintPath>
     </Reference>
-    <Reference Include="StyleCop.CSharp, Version=4.7.1000.0, Culture=neutral, PublicKeyToken=f904653c63bc2738, processorArchitecture=MSIL">
-      <HintPath>..\packages\StyleCop.Rules.4.7.49\lib\net40\StyleCop.CSharp.dll</HintPath>
       <Private>True</Private>
+    <Reference Include="StyleCop.CSharp">
+      <HintPath>..\packages\StyleCop.MSBuild.4.7.55.0\tools\StyleCop.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="StyleCop.CSharp.Rules, Version=4.7.1000.0, Culture=neutral, PublicKeyToken=f904653c63bc2738, processorArchitecture=MSIL">
-      <HintPath>..\packages\StyleCop.Rules.4.7.49\lib\net40\StyleCop.CSharp.Rules.dll</HintPath>
       <Private>True</Private>
+    <Reference Include="StyleCop.CSharp.Rules">
+      <HintPath>..\packages\StyleCop.MSBuild.4.7.55.0\tools\StyleCop.CSharp.Rules.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Cake.Stylecop/Cake.StyleCop.csproj
+++ b/Cake.Stylecop/Cake.StyleCop.csproj
@@ -40,17 +40,17 @@
       <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-      <Private>True</Private>
     <Reference Include="StyleCop">
       <HintPath>..\packages\StyleCop.MSBuild.4.7.55.0\tools\StyleCop.dll</HintPath>
-    </Reference>
       <Private>True</Private>
+    </Reference>
     <Reference Include="StyleCop.CSharp">
       <HintPath>..\packages\StyleCop.MSBuild.4.7.55.0\tools\StyleCop.CSharp.dll</HintPath>
-    </Reference>
       <Private>True</Private>
+    </Reference>
     <Reference Include="StyleCop.CSharp.Rules">
       <HintPath>..\packages\StyleCop.MSBuild.4.7.55.0\tools\StyleCop.CSharp.Rules.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Cake.Stylecop/packages.config
+++ b/Cake.Stylecop/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Cake.Common" version="0.17.0" targetFramework="net45" />
   <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
-  <package id="StyleCop.Rules" version="4.7.49" targetFramework="net45" />
+  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" />
 </packages>

--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,9 @@
+##########################################################################
+# This is the Cake bootstrapper script for PowerShell.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
 <#
 
 .SYNOPSIS
@@ -22,6 +28,10 @@ Performs a dry run of the build script.
 No tasks will be executed.
 .PARAMETER Mono
 Tells Cake to use the Mono scripting engine.
+.PARAMETER SkipToolPackageRestore
+Skips restoring of packages.
+.PARAMETER ScriptArgs
+Remaining arguments are added here.
 
 .LINK
 http://cakebuild.net
@@ -32,6 +42,7 @@ http://cakebuild.net
 Param(
     [string]$Script = "build.cake",
     [string]$Target = "Default",
+    [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
     [string]$Verbosity = "Verbose",
@@ -44,14 +55,43 @@ Param(
     [string[]]$ScriptArgs
 )
 
+[Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
+function MD5HashFile([string] $filePath)
+{
+    if ([string]::IsNullOrEmpty($filePath) -or !(Test-Path $filePath -PathType Leaf))
+    {
+        return $null
+    }
+
+    [System.IO.Stream] $file = $null;
+    [System.Security.Cryptography.MD5] $md5 = $null;
+    try
+    {
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        $file = [System.IO.File]::OpenRead($filePath)
+        return [System.BitConverter]::ToString($md5.ComputeHash($file))
+    }
+    finally
+    {
+        if ($file -ne $null)
+        {
+            $file.Dispose()
+        }
+    }
+}
+
 Write-Host "Preparing to run build script..."
 
-$PS_SCRIPT_ROOT = split-path -parent $MyInvocation.MyCommand.Definition;
+if(!$PSScriptRoot){
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
 $TOOLS_DIR = Join-Path $PSScriptRoot "tools"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
-$NUGET_URL = "http://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 $CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
+$PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 
 # Should we use mono?
 $UseMono = "";
@@ -82,7 +122,7 @@ if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
 # Make sure that packages.config exist.
 if (!(Test-Path $PACKAGES_CONFIG)) {
     Write-Verbose -Message "Downloading packages.config..."
-    try { Invoke-WebRequest -Uri http://cakebuild.net/bootstrapper/packages -OutFile $PACKAGES_CONFIG } catch {
+    try { (New-Object System.Net.WebClient).DownloadFile("http://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
         Throw "Could not download packages.config."
     }
 }
@@ -90,7 +130,7 @@ if (!(Test-Path $PACKAGES_CONFIG)) {
 # Try find NuGet.exe in path if not exists
 if (!(Test-Path $NUGET_EXE)) {
     Write-Verbose -Message "Trying to find nuget.exe in PATH..."
-    $existingPaths = $Env:Path -Split ';' | Where-Object { Test-Path $_ }
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_) }
     $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
     if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
         Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
@@ -112,21 +152,30 @@ if (!(Test-Path $NUGET_EXE)) {
 $ENV:NUGET_EXE = $NUGET_EXE
 
 # Restore tools from NuGet?
-if(-Not $SkipToolPackageRestore.IsPresent)
-{
-    # Restore packages from NuGet.
+if(-Not $SkipToolPackageRestore.IsPresent) {
     Push-Location
     Set-Location $TOOLS_DIR
 
+    # Check for changes in packages.config and remove installed tools if true.
+    [string] $md5Hash = MD5HashFile($PACKAGES_CONFIG)
+    if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
+      ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
+        Write-Verbose -Message "Missing or changed package.config hash..."
+        Remove-Item * -Recurse -Exclude packages.config,nuget.exe
+    }
+
     Write-Verbose -Message "Restoring tools from NuGet..."
     $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
-    Write-Verbose -Message ($NuGetOutput | out-string)
 
-    Pop-Location
-    if ($LASTEXITCODE -ne 0)
-    {
-        exit $LASTEXITCODE
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occured while restoring NuGet tools."
     }
+    else
+    {
+        $md5Hash | Out-File $PACKAGES_CONFIG_MD5 -Encoding "ASCII"
+    }
+    Write-Verbose -Message ($NuGetOutput | out-string)
+    Pop-Location
 }
 
 # Make sure that Cake has been installed.


### PR DESCRIPTION
See defect #8. The existing nuget package that was used was not an official release from StyleCop authors, just a convenient collection of the important dlls back in 2015.  I've updated it to the offical stylecop nuget, which does admittedly include some cruft not needed but at least it allows the use of the latest version.