### PR TITLE
Added ability to specify concrete project/projects to analyze

### DIFF
--- a/Cake.Stylecop/StyleCopSettings.cs
+++ b/Cake.Stylecop/StyleCopSettings.cs
@@ -13,6 +13,7 @@
         public StyleCopSettings()
         {
             Addins = new DirectoryPathCollection(new PathComparer(false));
+            ProjectFiles = new FilePathCollection(new PathComparer(false));
         }
 
         /// <summary>
@@ -63,5 +64,10 @@
         /// The StyleSheet Path
         /// </summary>
         public FilePath StyleSheet { get; set; }
+
+        /// <summary>
+        /// The list of project paths to analyze
+        /// </summary>
+        public FilePathCollection ProjectFiles { get; set; }
     }
 }

--- a/Cake.Stylecop/StyleCopSettingsExtensions.cs
+++ b/Cake.Stylecop/StyleCopSettingsExtensions.cs
@@ -10,6 +10,39 @@ namespace Cake.Stylecop
     public static class StyleCopSettingsExtensions
     {
         /// <summary>
+        /// Specifies the .net project to analyse.
+        /// </summary>
+        /// <param name="settings">The settings object.</param>
+        /// <param name="projectFile">FilePath of the .csproj file.</param>
+        /// <returns>Settings object.</returns>
+        public static StyleCopSettings WithProject(this StyleCopSettings settings, FilePath projectFile)
+        {
+            if (projectFile == null)
+            {
+                throw new ArgumentNullException(nameof(projectFile), "Project file path is null.");
+            }
+
+            settings.ProjectFiles.Add(projectFile);
+            return settings;
+        }
+
+        /// <summary>
+        /// Specifies the list of .net projects to analyse.
+        /// </summary>
+        /// <param name="settings">The settings object.</param>
+        /// <param name="projectFiles">FilePath of the .csproj files.</param>
+        /// <returns>Settings object.</returns>
+        public static StyleCopSettings WithProjects(this StyleCopSettings settings, params FilePath[] projectFiles)
+        {
+            foreach (var projectFile in projectFiles)
+            {
+                WithProject(settings, projectFile);
+            }
+            
+            return settings;
+        }
+
+        /// <summary>
         /// Specifies the .net solution to analyse.
         /// </summary>
         /// <param name="settings">The settings object.</param>

--- a/README.MD
+++ b/README.MD
@@ -38,6 +38,39 @@ Task("StyleCop")
 RunTarget(target);
 ```
 
+## Analyze not all projects
+
+Methods WithProject() or WithProjects() are useful in case if you do not need to analyze all projects in solution or if you have different stylecop settings for different projects inside your solution.
+
+```csharp
+var target = Argument("target", "StyleCop");
+
+Task("StyleCop")
+  .Does(() =>
+{
+    // project file
+    var projectFile = File("SolutionFolder/FirstOfMany.csproj");
+
+    // stylecop settings file
+    var settingsFile = File("Settings.stylecop");
+    
+    // xml results file
+    var resultFile = File("StylecopResults.xml");
+
+    // html report file
+    var htmlFile = File("StylecopResults.html");
+
+    StyleCopAnalyse(settings => settings
+        .WithProject(projectFile)
+        .WithSettings(settingsFile)
+        .ToResultFile(resultFile)
+        .ToHtmlReport(htmlFile)
+    );
+});
+
+RunTarget(target);
+```
+
 ## Merging multiple stylecop result files
 
 A second method is available if you need to merge several result files together to produce one report. This is useful for many CI servers


### PR DESCRIPTION
I added ability to specify just one project / collection of projects that user can analyze.
It would be useful in following cases:
-Projects in solution have different stylecop settings. (In such case, merging different xml results would make sense)
-You want to exclude legacy/test projects from stylecop check