### PR TITLE
Upgrade to net46 and Cake v0.22.0

### DIFF
--- a/Cake.Stylecop/Cake.StyleCop.csproj
+++ b/Cake.Stylecop/Cake.StyleCop.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.StyleCop</RootNamespace>
     <AssemblyName>Cake.StyleCop</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,12 +33,12 @@
     <DocumentationFile>bin\Release\Cake.StyleCop.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Common, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Common.0.17.0\lib\net45\Cake.Common.dll</HintPath>
+    <Reference Include="Cake.Common, Version=0.22.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Common.0.22.0\lib\net46\Cake.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.22.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.22.0\lib\net46\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="StyleCop, Version=4.7.1000.0, Culture=neutral, PublicKeyToken=f904653c63bc2738, processorArchitecture=MSIL">

--- a/Cake.Stylecop/Cake.StyleCop.csproj
+++ b/Cake.Stylecop/Cake.StyleCop.csproj
@@ -73,8 +73,13 @@
     <Compile Include="StyleCopSettingsExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Cake.Stylecop.nuspec" />
+    <None Include="Cake.Stylecop.nuspec">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
+    <None Include="Stylecop.xss">
+      <DependentUpon>Stylecop.xsd</DependentUpon>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="resources\error.png">
@@ -95,6 +100,9 @@
     <Content Include="StylecopStyleSheet.xslt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <None Include="Stylecop.xsc">
+      <DependentUpon>Stylecop.xsd</DependentUpon>
+    </None>
     <None Include="Stylecop.xsd" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Cake.Stylecop/Cake.StyleCop.nuspec
+++ b/Cake.Stylecop/Cake.StyleCop.nuspec
@@ -15,16 +15,16 @@
     <tags>Cake StyleCop</tags>
   </metadata>
   <files>
-    <file src="bin/Release/StyleCopStyleSheet.xslt" target="lib/net45" />
-    <file src="bin/Release/StyleCop.dll" target="lib/net45" />    
-    <file src="bin/Release/StyleCop.CSharp.dll" target="lib/net45" />
-    <file src="bin/Release/StyleCop.CSharp.Rules.dll" target="lib/net45" />
-    <file src="bin/Release/Cake.StyleCop.dll" target="lib/net45" />
-    <file src="bin/Release/Cake.StyleCop.XML" target="lib/net45" />
-    <file src="bin/Release/resources/error.png" target="lib/net45/resources" />
-    <file src="bin/Release/resources/minus.png" target="lib/net45/resources" />
-    <file src="bin/Release/resources/plus.png" target="lib/net45/resources" />
-    <file src="bin/Release/resources/report.js" target="lib/net45/resources" />
-    <file src="bin/Release/resources/stylecop.css" target="lib/net45/resources" />
+    <file src="bin/Release/StyleCopStyleSheet.xslt" target="lib\net46" />
+    <file src="bin/Release/StyleCop.dll" target="lib\net46" />    
+    <file src="bin/Release/StyleCop.CSharp.dll" target="lib\net46" />
+    <file src="bin/Release/StyleCop.CSharp.Rules.dll" target="lib\net46" />
+    <file src="bin/Release/Cake.StyleCop.dll" target="lib\net46" />
+    <file src="bin/Release/Cake.StyleCop.XML" target="lib\net46" />
+    <file src="bin/Release/resources/error.png" target="lib\net46\resources" />
+    <file src="bin/Release/resources/minus.png" target="lib\net46\resources" />
+    <file src="bin/Release/resources/plus.png" target="lib\net46\resources" />
+    <file src="bin/Release/resources/report.js" target="lib\net46\resources" />
+    <file src="bin/Release/resources/stylecop.css" target="lib\net46\resources" />
   </files>
 </package>

--- a/Cake.Stylecop/packages.config
+++ b/Cake.Stylecop/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Common" version="0.17.0" targetFramework="net45" />
-  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
+  <package id="Cake.Common" version="0.22.0" targetFramework="net46" />
+  <package id="Cake.Core" version="0.22.0" targetFramework="net46" />
   <package id="StyleCop.Rules" version="4.7.49" targetFramework="net45" />
 </packages>

--- a/build.cake
+++ b/build.cake
@@ -4,8 +4,6 @@
 // To execute, run the following within powershell
 // ./Build.ps1 -Target "build"
 
-#Addin "Cake.StyleCop"
-
 // When debugging, use instead of the #Addin above.
 // Note: VS Build often leaves additional dlls in the /bin/* directory that Stylecop errors when attempting to load. Delete these as necessary.
 // #r "Cake.Stylecop/bin/Release/Cake.StyleCop.dll"
@@ -56,49 +54,8 @@ const string Configuration = "Release";
 
     });
     
-    Task("Code-Quality")
-        .IsDependentOn("Build")
-        .ContinueOnError()
-        .Does(() => {
-        
-			var settingsFile = solutionFile.Path.GetDirectory() + File("Settings.stylecop");
-            Information("Settings: " + settingsFile);
-			
-			var resultFile = stylecopResultsDir + File("StylecopResults.xml");
-            var htmlFile = stylecopReportsDir + File("StylecopResults.html");
-
-			bool rethrow = false;
-
-			try {
-				StyleCopAnalyse(settings => settings
-					.WithSolution(solutionFile)
-					.WithSettings(settingsFile)
-					.ToResultFile(resultFile)
-				);
-			} catch (Exception exception) {
-				rethrow = true;
-			} finally {
-				var resultFilePattern = stylecopResultsDir.Path + "/*.xml";
-				Information("resultFilePattern: {0}", resultFilePattern);
-				
-				var resultFiles = GetFiles(resultFilePattern);
-				foreach(var file in resultFiles){
-					Information("resultFile: {0}", file.FullPath);
-				}
-            
-				StyleCopReport(settings => settings
-					.ToHtmlReport(htmlFile)
-					.AddResultFiles(resultFiles)
-				); 
-
-				if (rethrow) {
-					throw new Exception("Stylecop violations discovered.");
-				}
-			}
-        });
-
     Task("Package")
-    .IsDependentOn("Code-Quality")
+    .IsDependentOn("Build")
     .Does(() => {
 	
 		var nuGetPackSettings   = new NuGetPackSettings {

--- a/build.cake
+++ b/build.cake
@@ -59,7 +59,7 @@ const string Configuration = "Release";
     .Does(() => {
 	
 		var nuGetPackSettings   = new NuGetPackSettings {
-		Version                 = "1.1.3",
+		Version                 = "1.1.4",
 		BasePath                = "./Cake.StyleCop",
 		OutputDirectory         = nupkgDestDir
 		};

--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,9 @@
+##########################################################################
+# This is the Cake bootstrapper script for PowerShell.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
 <#
 
 .SYNOPSIS
@@ -22,6 +28,10 @@ Performs a dry run of the build script.
 No tasks will be executed.
 .PARAMETER Mono
 Tells Cake to use the Mono scripting engine.
+.PARAMETER SkipToolPackageRestore
+Skips restoring of packages.
+.PARAMETER ScriptArgs
+Remaining arguments are added here.
 
 .LINK
 http://cakebuild.net
@@ -30,8 +40,9 @@ http://cakebuild.net
 
 [CmdletBinding()]
 Param(
-    [string]$Script = "build.cake",
+    [string]$Script = "./build.cake",
     [string]$Target = "Default",
+    [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
     [string]$Verbosity = "Verbose",
@@ -44,14 +55,43 @@ Param(
     [string[]]$ScriptArgs
 )
 
+[Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
+function MD5HashFile([string] $filePath)
+{
+    if ([string]::IsNullOrEmpty($filePath) -or !(Test-Path $filePath -PathType Leaf))
+    {
+        return $null
+    }
+
+    [System.IO.Stream] $file = $null;
+    [System.Security.Cryptography.MD5] $md5 = $null;
+    try
+    {
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        $file = [System.IO.File]::OpenRead($filePath)
+        return [System.BitConverter]::ToString($md5.ComputeHash($file))
+    }
+    finally
+    {
+        if ($file -ne $null)
+        {
+            $file.Dispose()
+        }
+    }
+}
+
 Write-Host "Preparing to run build script..."
 
-$PS_SCRIPT_ROOT = split-path -parent $MyInvocation.MyCommand.Definition;
+if(!$PSScriptRoot){
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
 $TOOLS_DIR = Join-Path $PSScriptRoot "tools"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
-$NUGET_URL = "http://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 $CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
+$PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 
 # Should we use mono?
 $UseMono = "";
@@ -82,7 +122,7 @@ if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
 # Make sure that packages.config exist.
 if (!(Test-Path $PACKAGES_CONFIG)) {
     Write-Verbose -Message "Downloading packages.config..."
-    try { Invoke-WebRequest -Uri http://cakebuild.net/bootstrapper/packages -OutFile $PACKAGES_CONFIG } catch {
+    try { (New-Object System.Net.WebClient).DownloadFile("http://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
         Throw "Could not download packages.config."
     }
 }
@@ -90,7 +130,7 @@ if (!(Test-Path $PACKAGES_CONFIG)) {
 # Try find NuGet.exe in path if not exists
 if (!(Test-Path $NUGET_EXE)) {
     Write-Verbose -Message "Trying to find nuget.exe in PATH..."
-    $existingPaths = $Env:Path -Split ';' | Where-Object { Test-Path $_ }
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_) }
     $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
     if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
         Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
@@ -112,21 +152,30 @@ if (!(Test-Path $NUGET_EXE)) {
 $ENV:NUGET_EXE = $NUGET_EXE
 
 # Restore tools from NuGet?
-if(-Not $SkipToolPackageRestore.IsPresent)
-{
-    # Restore packages from NuGet.
+if(-Not $SkipToolPackageRestore.IsPresent) {
     Push-Location
     Set-Location $TOOLS_DIR
 
+    # Check for changes in packages.config and remove installed tools if true.
+    [string] $md5Hash = MD5HashFile($PACKAGES_CONFIG)
+    if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
+      ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
+        Write-Verbose -Message "Missing or changed package.config hash..."
+        Remove-Item * -Recurse -Exclude packages.config,nuget.exe
+    }
+
     Write-Verbose -Message "Restoring tools from NuGet..."
     $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
-    Write-Verbose -Message ($NuGetOutput | out-string)
 
-    Pop-Location
-    if ($LASTEXITCODE -ne 0)
-    {
-        exit $LASTEXITCODE
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occured while restoring NuGet tools."
     }
+    else
+    {
+        $md5Hash | Out-File $PACKAGES_CONFIG_MD5 -Encoding "ASCII"
+    }
+    Write-Verbose -Message ($NuGetOutput | out-string)
+    Pop-Location
 }
 
 # Make sure that Cake has been installed.


### PR DESCRIPTION
Upgrade the source code to the latest  Cake version. A pre-requisite of the new Cake is to upgrade the compiler version to .net 46.