### PR TITLE
Add DoNotFail and SuppressOutput extension methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ packages
 Thumbs.db
 nuget/
 /.vs/config/applicationhost.config
+/.vs

--- a/Cake.Stylecop/StyleCopHandlers.cs
+++ b/Cake.Stylecop/StyleCopHandlers.cs
@@ -10,6 +10,7 @@
     public class StylecopHandlers
     {
         private readonly ICakeContext _context;
+        private readonly StyleCopSettings _settings;
 
         private int _totalViolations;
 
@@ -17,9 +18,10 @@
         /// Creates a new instance.
         /// </summary>
         /// <param name="context">The context.</param>
-        public StylecopHandlers(ICakeContext context)
+        public StylecopHandlers(ICakeContext context, StyleCopSettings settings)
         {
             _context = context;
+            _settings = settings;
         }
 
         /// <summary>
@@ -52,9 +54,12 @@
         {
             _totalViolations++;
 
-            Cake.Common.Diagnostics.LoggingAliases.Error(
-                _context,
-                string.Format("{0}: {1} @ Line {2}", args.Violation.Rule.CheckId, args.Message, args.LineNumber));
+            if (_settings.OutputIssues)
+            {
+                Cake.Common.Diagnostics.LoggingAliases.Error(
+                    _context,
+                    string.Format("{0}: {1} @ Line {2}", args.Violation.Rule.CheckId, args.Message, args.LineNumber));
+            }
         }
     }
 }

--- a/Cake.Stylecop/StyleCopRunner.cs
+++ b/Cake.Stylecop/StyleCopRunner.cs
@@ -103,7 +103,7 @@
                 }
             }
 
-            var handler = new StylecopHandlers(context);
+            var handler = new StylecopHandlers(context, settings);
 
             styleCopConsole.OutputGenerated += handler.OnOutputGenerated;
             styleCopConsole.ViolationEncountered += handler.ViolationEncountered;
@@ -124,7 +124,7 @@
                 Transform(context, settings.HtmlReportFile, settings.ResultsFile.MakeAbsolute(context.Environment), settings.StyleSheet ?? context.MakeAbsolute(defaultStyleSheet));
             }
 
-            if (handler.TotalViolations > 0)
+            if (handler.TotalViolations > 0 && settings.FailTask)
             {
                 throw new Exception($"{handler.TotalViolations} StyleCop violations encountered.");
             }

--- a/Cake.Stylecop/StyleCopSettings.cs
+++ b/Cake.Stylecop/StyleCopSettings.cs
@@ -13,6 +13,8 @@
         public StyleCopSettings()
         {
             Addins = new DirectoryPathCollection(new PathComparer(false));
+            FailTask = true;
+            OutputIssues = true;
         }
 
         /// <summary>
@@ -63,5 +65,15 @@
         /// The StyleSheet Path
         /// </summary>
         public FilePath StyleSheet { get; set; }
+
+        /// <summary>
+        /// Indicates whether to fail the cake task.
+        /// </summary>
+        public bool FailTask { get; set; }
+
+        /// <summary>
+        /// Indicates whether to output stylecop validation errors.
+        /// </summary>
+        public bool OutputIssues { get; set; }
     }
 }

--- a/Cake.Stylecop/StyleCopSettingsExtensions.cs
+++ b/Cake.Stylecop/StyleCopSettingsExtensions.cs
@@ -132,5 +132,27 @@ namespace Cake.Stylecop
             settings.ResultFiles = resultFiles;
             return settings;
         }
+
+        /// <summary>
+        /// Indicates that the task should not fail upon encountering validation issues.
+        /// </summary>
+        /// <param name="settings">The settings object.</param>
+        /// <returns>Settings object.</returns>
+        public static StyleCopSettings DoNotFailTask(this StyleCopSettings settings)
+        {
+            settings.FailTask = false;
+            return settings;
+        }
+
+        /// <summary>
+        /// Indicates that validation issues should not be written to stderr.
+        /// </summary>
+        /// <param name="settings">The settings object.</param>
+        /// <returns>Settings object.</returns>
+        public static StyleCopSettings SuppressOutput(this StyleCopSettings settings)
+        {
+            settings.OutputIssues = false;
+            return settings;
+        }
     }
 }


### PR DESCRIPTION
DoNotFail  can be used to prevent Cake task failure. Usefull if the build is running on a build server and we really just want to output the results in a info tab other than failing the entire build.
SuppressOutput is usefull when you're checking stderr for failing the build or you just don't want all that noise in build logs.